### PR TITLE
update get_lines() to use httr::GET()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Imports:
     dplyr,
     scales,
     tidyr,
-    stringr
+    stringr,
+    httr
 Suggests: 
     testthat,
     knitr,

--- a/R/get_lines.R
+++ b/R/get_lines.R
@@ -133,10 +133,12 @@ get_lines <- function(sport = "NFL",
     }
   }
 
-  ## need to loop eventually...
-  oddspage <- xml2::read_html(oddsURL)
-  node <-
-    rvest::html_nodes(oddspage, "div.event-holder.holder-complete")
+  # for some reason xml2::read_html throwing 463, switching to httr::GET
+  res <- httr::GET(oddsURL)
+  con <- httr::content(res, 'text')
+  oddspage <- xml2::read_html(con)
+
+  node <- rvest::html_nodes(oddspage, "div.event-holder.holder-complete")
   games <- length(node)
 
   # initialize results


### PR DESCRIPTION
 This PR is intended to fix the 463 error being thrown when calling `get_lines()`. While initially I suspected that this was due to a missing user-agent in the header, I'm not so sure now; in any case, grabbing the page's content using `httr::GET()` appears to work. Unit tests continue to pass.